### PR TITLE
small typo on the CLI help

### DIFF
--- a/src/bin/sekey.rs
+++ b/src/bin/sekey.rs
@@ -78,7 +78,7 @@ fn main() {
                                 .long("delete-keypair")
                                 .short("d")
                                 .value_name("ID")
-                                .help("Deltes the keypair")
+                                .help("Deletes the keypair")
                                 .takes_value(true)
                                 .conflicts_with_all(&["list-keys"]))
                       .get_matches();


### PR DESCRIPTION
when you run sekey --help, "--delete-keypar" shows the text: "Deltes the keypair", and it should be "**Deletes** the keypair"