### PR TITLE
removed doubled 'sekey' from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ OPTIONS:
 Create KeyPair inside the Secure Enclave:
 
 ```sh
-ntrippar@macbookpro:~% sekey sekey --generate-keypair "Github Key"
+ntrippar@macbookpro:~% sekey --generate-keypair "Github Key"
 Keypair Github Key sucessfully generated
 
 ```


### PR DESCRIPTION
removed doubled 'sekey' from create keypair example