### PR TITLE
Change CFBundleName to match app name

### DIFF
--- a/bundle/Applications/SeKey.app/Contents/Info.plist
+++ b/bundle/Applications/SeKey.app/Contents/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string></string>
 	<key>CFBundleName</key>
-	<string>com.ntrippar.sekey</string>
+	<string>SeKey</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
From the docs for `CFBundleName` ([ref](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlename)):

> A user-visible short name for the bundle.

This fixes #47