### PR TITLE
Small changes to fix some warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ core-foundation = "0.4.6"
 libc = "0.2"
 prettytable-rs = "0.6.7"
 hex = "0.3.1"
+home = "0.5.3"
 rust-crypto = "0.2.36"
 ssh_agent = { git = 'https://github.com/ntrippar/ssh-agent' }
 

--- a/src/bin/sekey.rs
+++ b/src/bin/sekey.rs
@@ -2,6 +2,7 @@ extern crate sekey;
 extern crate env_logger;
 extern crate ssh_agent;
 extern crate clap;
+extern crate home;
 #[macro_use]
 extern crate prettytable;
 extern crate hex;
@@ -21,9 +22,6 @@ use ssh_agent::SSHAgentHandler;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use std::env;
-
-
 
 static SEKEY_HOME_FOLDER: &'static str = "/.sekey/";
 static SSH_AGENT_PIPE: &'static str = "ssh-agent.ssh";
@@ -47,42 +45,42 @@ fn main() {
     });
 
     let matches = App::new("SeKey")
-                      .version("1.0")
-                      .author("Nicolas Trippar <ntrippar@gmail.com>")
-                      .about("Use Secure Enclave for SSH Authentication")
-                      .arg(Arg::with_name("generate-keypair")
-                                .long("generate-keypair")
-                                .short("c")
-                                .value_name("LABEL")
-                                .help("Generate a key inside the Secure Enclave")
-                                .takes_value(true))
-                      .arg(Arg::with_name("list-keys")
-                                .long("list-keys")
-                                .short("l")
-                                .help("List all keys")
-                                .takes_value(false)
-                                .conflicts_with_all(&["generate-keypair"]))
-                          .arg(Arg::with_name("daemon")
-                                .long("daemon")
-                                .help("Run the daemon")
-                                .takes_value(false)
-                                .conflicts_with_all(&["list-keys"]))
-                      .arg(Arg::with_name("export-key")
-                                .long("export-key")
-                                .short("e")
-                                .value_name("ID")
-                                .help("export key to OpenSSH Format")
-                                .takes_value(true)
-                                .conflicts_with_all(&["list-keys"]))
-                      .arg(Arg::with_name("delete-keypair")
-                                .long("delete-keypair")
-                                .short("d")
-                                .value_name("ID")
-                                .help("Deletes the keypair")
-                                .takes_value(true)
-                                .conflicts_with_all(&["list-keys"]))
-                      .get_matches();
-
+        .version("1.0")
+	.author("Nicolas Trippar <ntrippar@gmail.com>")
+        .about("Use Secure Enclave for keys")
+        .arg(Arg::with_name("generate-keypair")
+             .long("generate-keypair")
+             .short("c")
+             .value_name("LABEL")
+             .help("Generate a key inside the Secure Enclave")
+             .takes_value(true))
+        .arg(Arg::with_name("list-keys")
+             .long("list-keys")
+             .short("l")
+             .help("List all keys")
+             .takes_value(false)
+             .conflicts_with_all(&["generate-keypair"]))
+        .arg(Arg::with_name("daemon")
+             .long("daemon")
+             .help("Run the daemon")
+             .takes_value(false)
+             .conflicts_with_all(&["list-keys"]))
+        .arg(Arg::with_name("export-key")
+             .long("export-key")
+             .short("e")
+             .value_name("ID")
+             .help("export key to OpenSSH Format")
+             .takes_value(true)
+             .conflicts_with_all(&["list-keys"]))
+        .arg(Arg::with_name("delete-keypair")
+             .long("delete-keypair")
+             .short("d")
+             .value_name("ID")
+             .help("Deletes the keypair")
+             .takes_value(true)
+             .conflicts_with_all(&["list-keys"]))
+        .get_matches();
+    
     // printing format
     let format = format::FormatBuilder::new()
         .column_separator('│')
@@ -160,7 +158,7 @@ fn main() {
     //generate_keypair
     // run the daemon!
     if matches.is_present("daemon") {
-        match env::home_dir() {
+        match home::home_dir() {
             Some(path) => {
                 match create_home_path(path.clone()){
                     Ok(_) => {

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -14,7 +14,7 @@ der_sequence!{
 		s: NOTAG TYPE Vec<u8>,
 }
 
-pub static CURVE_INDETIFIER: &'static str = "nistp256";
+pub static CURVE_IDENTIFIER: &'static str = "nistp256";
 pub static CURVE_TYPE: &'static str = "ecdsa-sha2-nistp256";
 
 pub struct EcdsaSha2Nistp256;
@@ -23,17 +23,17 @@ impl EcdsaSha2Nistp256 {
 	// write to SSH-Key Format
 	pub fn write(key: Vec<u8>) -> Vec<u8> {
 		let curvetype = String::from(CURVE_TYPE);
-		let identifier = String::from(CURVE_INDETIFIER);
+		let identifier = String::from(CURVE_IDENTIFIER);
 		let mut data = vec![];
 		//write curve type
 		data.write_u32::<BigEndian>(curvetype.len() as u32).unwrap();
-		data.write_all(curvetype.as_bytes());
+		data.write_all(curvetype.as_bytes()).expect("error writing data!");
 		//write identifier
 		data.write_u32::<BigEndian>(identifier.len() as u32).unwrap();
-		data.write_all(identifier.as_bytes());
+		data.write_all(identifier.as_bytes()).expect("error writing data!");
 		//write key
 		data.write_u32::<BigEndian>(key.len() as u32).unwrap();
-		data.write_all(key.as_slice());
+		data.write_all(key.as_slice()).expect("error writing data!") ;
 		data 
 	}
 
@@ -47,7 +47,7 @@ impl EcdsaSha2Nistp256 {
 		cursor.consume(len as usize);
 		let len = cursor.read_u32::<BigEndian>().unwrap();
 		let mut buffer = vec![0; len as usize];
-		cursor.read(&mut buffer);
+		cursor.read(&mut buffer).expect("error reading SSH Key") ;
 		buffer
 	}
 


### PR DESCRIPTION
I found some warnings when I built the project (rustc 1.49-beta3 on MacOS BigSur). 

One of them seems to be because the use of env:home_dir is deprecated in favour (so far) of the 'home' crate with the same function name. The other warning appears to be because write_all can return an error if an individual write fails, which means the code was ignoring a result, so I added an 'expect' to each of the write_all calls. 